### PR TITLE
Update generalized_phase_vector.m

### DIFF
--- a/analysis/generalized_phase_vector.m
+++ b/analysis/generalized_phase_vector.m
@@ -52,7 +52,11 @@ if all( isnan(ph) ), xgp = nan( size(xo) ); return; end
 idx = ( wt < lp ); idx(1) = 0; [L,G] = bwlabel( idx );
 for kk = 1:G
     idxs = find( L == kk );
-    idx( idxs(1):( idxs(1) + ((idxs(end)-idxs(1))*nwin) ) ) = true;
+    if (idxs(1) + ((idxs(end)-idxs(1))*nwin)) > npts
+        idx( idxs(1):npts ) = true;
+    else
+        idx( idxs(1):( idxs(1) + ((idxs(end)-idxs(1))*nwin) ) ) = true;
+    end
 end
 
 % "stitch over" negative frequency epochs


### PR DESCRIPTION
Hi Lyle,

GP is the solution I've always wanted by could never implement in a rigorous way. Thanks for sharing!

I came across a minor issue where negative frequency epochs at or near the end of the data segment cause idx to overrun the length of the segment if nwin is set >1. This pull request is a simple fix to prevent that from happening. 

What is the purpose of extending the epoch with nwin? Just to smooth things out? What happens if it is set to 1?

I'm in the process of incorporating GP into my analysis pipeline, I'll let you know how it performs and if I run into any other issues.

Thanks again,
David
