### PR TITLE
Unwrap phase before interpolating

### DIFF
--- a/analysis/generalized_phase.m
+++ b/analysis/generalized_phase.m
@@ -64,9 +64,12 @@ for ii = 1:rows
 		end
 
 		% "stitch over" negative frequency epochs
-		p = squeeze( ph(ii,jj,:) ); p(idx) = NaN; 
+		p = squeeze( ph(ii,jj,:) );
+		p = unwrap(p);
+		p(idx) = NaN; 
 		if all( isnan(p) ), continue; end % check if all NaNs
-		p = unwrap(p); p(isnan(p)) = naninterp( p ); p = rewrap( p );
+		p(isnan(p)) = naninterp( p );
+		p = rewrap( p );
 		ph(ii,jj,:) = p(1:size(ph,3));
 
 	end

--- a/analysis/generalized_phase_vector.m
+++ b/analysis/generalized_phase_vector.m
@@ -56,9 +56,13 @@ for kk = 1:G
 end
 
 % "stitch over" negative frequency epochs
-p = ph; p(idx) = NaN;
+p = ph;
+p = unwrap(p);
+p(idx) = NaN;
 if all( isnan(p) ), xgp = nan( size(xo) ); return; end % check if all NaNs
-p = unwrap(p); p(isnan(p)) = naninterp( p ); p = rewrap( p ); ph = p;
+p(isnan(p)) = naninterp( p );
+p = rewrap( p );
+ph = p;
 
 % output
 xgp = md .* exp( 1i .* ph );


### PR DESCRIPTION
Unwrapping phase can be inaccurate if performed after setting values to NaN for interpolation (i.e. if the NaN period overlaps with the wrapped phase crossing the pi boundary). This PR just places the unwrapping step before the NaN step.

# Unwrapping error:
(if NaNs are set before unwrapping)
### Wrapped
![image](https://user-images.githubusercontent.com/42064608/175278569-000e3776-c02f-4eeb-b21d-f6b925551131.png)

### Unwrapped
![image](https://user-images.githubusercontent.com/42064608/175278757-5d18246f-39a1-4673-b612-889c5f9cdc31.png)


# Before
### Unwrapped
![image](https://user-images.githubusercontent.com/42064608/175278374-5dd3447d-389a-4f14-a1b7-52724ed8157b.png)

### Wrapped
![image](https://user-images.githubusercontent.com/42064608/175277409-732df670-60cf-44b9-9f24-0075e4dd2952.png)


# After
### Unwrapped
![image](https://user-images.githubusercontent.com/42064608/175277921-6ae3771d-0ddf-4d3e-a9d9-007a5ea9dcf6.png)

### Wrapped
![image](https://user-images.githubusercontent.com/42064608/175277672-1a676c3c-4f2f-4c2e-bb9b-8ae3eab7210a.png)
